### PR TITLE
[IMP] sign_oca: Ensure inalterability

### DIFF
--- a/sign_oca/__manifest__.py
+++ b/sign_oca/__manifest__.py
@@ -15,6 +15,7 @@
         "views/menu.xml",
         "data/data.xml",
         "wizards/res_config_settings_views.xml",
+        "data/ir_sequence_data.xml",
         "wizards/sign_oca_template_generate.xml",
         "wizards/sign_oca_template_generate_multi.xml",
         "views/res_partner_views.xml",

--- a/sign_oca/controllers/main.py
+++ b/sign_oca/controllers/main.py
@@ -1,6 +1,3 @@
-import base64
-import io
-
 from odoo import http
 from odoo.exceptions import AccessError, MissingError
 from odoo.http import request
@@ -70,8 +67,9 @@ class PortalSign(CustomerPortal):
             )
         except (AccessError, MissingError):
             return request.redirect("/my")
-        data = io.BytesIO(base64.standard_b64decode(signer_sudo.request_id.data))
-        return http.send_file(data, filename=signer_sudo.request_id.name)
+        return http.Stream.from_binary_field(
+            signer_sudo.request_id, "data"
+        ).get_response(mimetype="application/pdf")
 
     @http.route(
         ["/sign_oca/info/<int:signer_id>/<string:access_token>"],

--- a/sign_oca/data/ir_sequence_data.xml
+++ b/sign_oca/data/ir_sequence_data.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo noupdate="1">
+    <record id="sign_inalterability_sequence" model="ir.sequence">
+        <field name="name">Securization of Signature</field>
+        <field name="code">SECUR_SIGN</field>
+        <field name="implementation">no_gap</field>
+        <field name="prefix" />
+        <field name="suffix" />
+        <field name="padding">0</field>
+        <field name="company_id" eval="False" />
+    </record>
+</odoo>

--- a/sign_oca/models/sign_oca_template.py
+++ b/sign_oca/models/sign_oca_template.py
@@ -132,7 +132,7 @@ class SignOcaTemplate(models.Model):
 class SignOcaTemplateItem(models.Model):
 
     _name = "sign.oca.template.item"
-    _description = "Sign Oca Template Item"  # TODO
+    _description = "Sign Oca Template Item"
 
     template_id = fields.Many2one(
         "sign.oca.template", required=True, ondelete="cascade"

--- a/sign_oca/views/sign_oca_request.xml
+++ b/sign_oca/views/sign_oca_request.xml
@@ -325,11 +325,12 @@
         <field name="name">sign.oca.request.signer.tree (in sign_oca)</field>
         <field name="model">sign.oca.request.signer</field>
         <field name="arch" type="xml">
-            <tree edit="0" delete="0" create="0">
+            <tree edit="0" delete="0" create="0" decoration-danger="altered_hash">
                 <field name="role_id" />
                 <field name="partner_id" />
                 <field name="request_id" />
                 <field name="signed_on" />
+                <field name="altered_hash" invisible="1" />
             </tree>
         </field>
     </record>
@@ -353,6 +354,7 @@
                         <field name="partner_id" readonly="1" />
                         <field name="request_id" readonly="1" />
                         <field name="signed_on" />
+                        <field name="inalterable_hash" />
                     </group>
                 </sheet>
             </form>


### PR DESCRIPTION
This change should allow us to make an inalterable signature item, making it much easier for us.

With `sign_oca` and `sign_biometric_oca` we should be able to have and advanced signature following eIDAS, making it legal