### PR TITLE
[14.0][IMP] sign_oca: preview requests

### DIFF
--- a/sign_oca/models/sign_oca_request.py
+++ b/sign_oca/models/sign_oca_request.py
@@ -76,6 +76,19 @@ class SignOcaRequest(models.Model):
                 record.signatory_data and max(record.signatory_data.keys()) or 0
             ) + 1
 
+    def preview(self):
+        self.ensure_one()
+        self._set_action_log("view")
+        return {
+            "type": "ir.actions.client",
+            "tag": "sign_oca_preview",
+            "name": self.name,
+            "params": {
+                "res_model": self._name,
+                "res_id": self.id,
+            },
+        }
+
     def get_info(self):
         self.ensure_one()
         return {

--- a/sign_oca/static/src/components/sign_oca_pdf_common/sign_oca_pdf_common_action.js
+++ b/sign_oca/static/src/components/sign_oca_pdf_common/sign_oca_pdf_common_action.js
@@ -1,0 +1,48 @@
+odoo.define(
+    "sign_oca/static/src/components/sign_oca_pdf_common/sign_oca_pdf_common_action.js",
+    function (require) {
+        "use strict";
+
+        const {ComponentWrapper} = require("web.OwlCompatibility");
+        const AbstractAction = require("web.AbstractAction");
+        const core = require("web.core");
+        const SignOcaPdfCommon = require("sign_oca/static/src/components/sign_oca_pdf_common/sign_oca_pdf_common.js");
+
+        const SignOcaPdfCommonAction = AbstractAction.extend({
+            hasControlPanel: true,
+            init: function (parent, action) {
+                this._super.apply(this, arguments);
+                this.model =
+                    (action.params.res_model !== undefined &&
+                        action.params.res_model) ||
+                    action.context.params.res_model;
+                this.res_id =
+                    (action.params.res_id !== undefined && action.params.res_id) ||
+                    action.context.params.id;
+            },
+            async start() {
+                await this._super(...arguments);
+                this.component = new ComponentWrapper(this, SignOcaPdfCommon, {
+                    model: this.model,
+                    res_id: this.res_id,
+                });
+                this.$el.addClass("o_sign_oca_action");
+                return this.component.mount(this.$(".o_content")[0]);
+            },
+            getState: function () {
+                var result = this._super(...arguments);
+                result = _.extend({}, result, {
+                    res_model: this.model,
+                    res_id: this.res_id,
+                });
+                return result;
+            },
+        });
+
+        core.action_registry.add("sign_oca_preview", SignOcaPdfCommonAction);
+
+        return {
+            SignOcaPdfCommonAction,
+        };
+    }
+);

--- a/sign_oca/templates/assets.xml
+++ b/sign_oca/templates/assets.xml
@@ -13,6 +13,10 @@
             />
             <script
                 type="text/javascript"
+                src="/sign_oca/static/src/components/sign_oca_pdf_common/sign_oca_pdf_common_action.js"
+            />
+            <script
+                type="text/javascript"
                 src="/sign_oca/static/src/elements/registry.js"
             />
             <script

--- a/sign_oca/views/sign_oca_request.xml
+++ b/sign_oca/views/sign_oca_request.xml
@@ -32,6 +32,8 @@
                 <sheet>
                     <div class="oe_button_box" name="button_box">
                         <button
+                            name="preview"
+                            type="object"
                             class="oe_stat_button"
                             icon="fa-pencil"
                             states="sent,signed"


### PR DESCRIPTION
This improvement allows previewing a sign request by clicking the signers counter button. If the request is signed, the preview will show the filled in information, otherwise will show the blank template.