### PR TITLE
[14.0][FIX] sign_oca: Set signatory data from old format to the new one

### DIFF
--- a/sign_oca/__manifest__.py
+++ b/sign_oca/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Sign Oca",
     "summary": """
         Allow to sign documents inside Odoo CE""",
-    "version": "14.0.2.4.3",
+    "version": "14.0.2.4.4",
     "license": "AGPL-3",
     "author": "Dixmit,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/sign",

--- a/sign_oca/migrations/14.0.2.4.4/post-migration.py
+++ b/sign_oca/migrations/14.0.2.4.4/post-migration.py
@@ -1,0 +1,22 @@
+# Copyright 2024 ForgeFlow <http://www.forgeflow.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    _logger.info("Set signatory data from old format to the new one.")
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    requests = env["sign.oca.request"].search([])
+    for request in requests:
+        items = request.signatory_data
+        for key in items:
+            item = items[key]
+            if item.get("role", False):
+                item["role_id"] = item["role"]
+                del item["role"]
+        request.write({"signatory_data": items})


### PR DESCRIPTION
We changed signatory data 'role' to 'role_id', so we should change it to old records.