### PR TITLE
[14.0][FIX] sign_oca: Get signer partner info

### DIFF
--- a/sign_oca/models/sign_oca_request.py
+++ b/sign_oca/models/sign_oca_request.py
@@ -361,10 +361,10 @@ class SignOcaRequestSigner(models.Model):
             "items": self.request_id.signatory_data,
             "to_sign": self.request_id.to_sign,
             "partner": {
-                "id": self.env.user.partner_id.id,
-                "name": self.env.user.partner_id.name,
-                "email": self.env.user.partner_id.email,
-                "phone": self.env.user.partner_id.phone,
+                "id": self.partner_id.id,
+                "name": self.partner_id.name,
+                "email": self.partner_id.email,
+                "phone": self.partner_id.phone,
             },
         }
 


### PR DESCRIPTION
When a signer signs a request, we will want to fetch the info from his partner instead of fetching from the active user. This allows to load the correct data for signers that do not have a user in the system like customers.

Before:
![image](https://github.com/OCA/sign/assets/90243017/011e0321-0dc6-4b51-834a-5c3004f2c088)

Now:
![image](https://github.com/OCA/sign/assets/90243017/9a7152ef-65b0-4129-961d-6f2eec76e4fb)
