### PR TITLE
[15.0][IMP] maintenance_sign_oca: Compatibility with hr_maintenance in tests

### DIFF
--- a/maintenance_sign_oca/models/maintenance_equipment.py
+++ b/maintenance_sign_oca/models/maintenance_equipment.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Tecnativa - Víctor Martínez
+# Copyright 2023-2024 Tecnativa - Víctor Martínez
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 from odoo import api, fields, models
 
@@ -56,6 +56,9 @@ class MaintenanceEquipment(models.Model):
             sign_template = item.company_id.maintenance_equipment_sign_oca_template_id
             old_owner_user_id = data[item.id] if item.id in data else False
             if sign_template and item.owner_user_id != old_owner_user_id:
+                # Apply sudo because the user who creates the record may not have
+                # permissions on sign.oca.template
+                sign_template = sign_template.sudo()
                 request_model.create(
                     sign_template._prepare_sign_oca_request_vals_from_record(item)
                 )

--- a/maintenance_sign_oca/tests/test_maintenance_sign_oca.py
+++ b/maintenance_sign_oca/tests/test_maintenance_sign_oca.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Tecnativa - Víctor Martínez
+# Copyright 2023-2024 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo.tests.common import Form, TransactionCase, new_test_user
@@ -25,12 +25,20 @@ class TestMaintenanceSignOca(TransactionCase):
         cls.model_maintenance_equipment = cls.env.ref(
             "maintenance.model_maintenance_equipment"
         )
-        cls.user_a = new_test_user(cls.env, login="test-user-a")
-        cls.equipment_a = cls.env["maintenance.equipment"].create(
+        cls.user_a = new_test_user(
+            cls.env, login="test-user-a", groups="maintenance.group_equipment_manager"
+        )
+        # Set a default to make it compatible with hr_maintenance
+        cls.equipment_model = cls.env["maintenance.equipment"].with_context(
+            default_equipment_assign_to="other"
+        )
+        cls.equipment_a = cls.equipment_model.with_user(cls.user_a).create(
             {"name": "Test equipment A", "owner_user_id": cls.user_a.id}
         )
-        cls.user_b = new_test_user(cls.env, login="test-user-b")
-        cls.equipment_b = cls.env["maintenance.equipment"].create(
+        cls.user_b = new_test_user(
+            cls.env, login="test-user-b", groups="maintenance.group_equipment_manager"
+        )
+        cls.equipment_b = cls.equipment_model.with_user(cls.user_b).create(
             {"name": "Test equipment B", "owner_user_id": cls.user_b.id}
         )
 
@@ -56,7 +64,7 @@ class TestMaintenanceSignOca(TransactionCase):
 
     def test_maintenance_equipment_create(self):
         self.company.maintenance_equipment_sign_oca_template_id = self.template
-        equipment_c = self.env["maintenance.equipment"].create(
+        equipment_c = self.equipment_model.with_user(self.user_a).create(
             {"name": "Test equipment C", "owner_user_id": self.user_a.id}
         )
         self.assertIn(


### PR DESCRIPTION
Compatibility with `hr_maintenance` in tests

If the `hr_maintenance` module is installed, the owner_user_id field is a compute so we make the tests compatible.

Please @pedrobaeza and @carolinafernandez-tecnativa can you review it?

@Tecnativa TT41745