### PR TITLE
[14.0][FIX] sign_oca: Filter correctly next_items

### DIFF
--- a/sign_oca/static/src/elements/check.js
+++ b/sign_oca/static/src/elements/check.js
@@ -42,7 +42,8 @@ odoo.define("sign_oca.checkElement", function (require) {
                 ev.preventDefault();
                 var next_items = _.filter(
                     parent.info.items,
-                    (i) => i.tabindex > item.tabindex && i.role_id === parent.role_id
+                    (i) =>
+                        i.tabindex > item.tabindex && i.role_id === parent.info.role_id
                 ).sort((a, b) => a.tabindex - b.tabindex);
                 if (next_items.length > 0) {
                     ev.currentTarget.blur();

--- a/sign_oca/static/src/elements/signature.js
+++ b/sign_oca/static/src/elements/signature.js
@@ -63,7 +63,9 @@ odoo.define("sign_oca.signatureElement", function (require) {
             this.getParent().checkFilledAll();
             var next_items = _.filter(
                 this.getParent().info.items,
-                (i) => i.tabindex > this.item.tabindex
+                (i) =>
+                    i.tabindex > this.item.tabindex &&
+                    i.role_id === this.getParent().info.role_id
             ).sort((a, b) => a.tabindex - b.tabindex);
             if (next_items.length > 0) {
                 this.getParent().items[next_items[0].id].dispatchEvent(

--- a/sign_oca/static/src/elements/text.js
+++ b/sign_oca/static/src/elements/text.js
@@ -42,7 +42,8 @@ odoo.define("sign_oca.textElement", function (require) {
                 ev.preventDefault();
                 var next_items = _.filter(
                     parent.info.items,
-                    (i) => i.tabindex > item.tabindex && i.role_id === parent.role_id
+                    (i) =>
+                        i.tabindex > item.tabindex && i.role_id === parent.info.role_id
                 ).sort((a, b) => a.tabindex - b.tabindex);
                 if (next_items.length > 0) {
                     ev.currentTarget.blur();


### PR DESCRIPTION
When we click 'Horizontal Tab' character we would expect to move the focus to the next item. Correctly filtering the next_items we will be able to do so.

Example:
https://github.com/OCA/sign/assets/90243017/a3504dc9-e728-4fab-8f5e-46180a5c62f2