### PR TITLE
[16.0][FIX] sign_oca: Get signer partner info

### DIFF
--- a/sign_oca/models/sign_oca_request.py
+++ b/sign_oca/models/sign_oca_request.py
@@ -363,10 +363,10 @@ class SignOcaRequestSigner(models.Model):
             "items": self.request_id.signatory_data,
             "to_sign": self.request_id.to_sign,
             "partner": {
-                "id": self.env.user.partner_id.id,
-                "name": self.env.user.partner_id.name,
-                "email": self.env.user.partner_id.email,
-                "phone": self.env.user.partner_id.phone,
+                "id": self.partner_id.id,
+                "name": self.partner_id.name,
+                "email": self.partner_id.email,
+                "phone": self.partner_id.phone,
             },
         }
 

--- a/sign_oca/tests/test_sign.py
+++ b/sign_oca/tests/test_sign.py
@@ -109,6 +109,9 @@ class TestSign(TransactionCase):
         self.assertFalse(self.request.get_info()["items"])
         self.configure_request()
         self.assertTrue(self.request.get_info()["items"])
+        signer_info = self.request.signer_ids.get_info()
+        self.assertEqual(signer_info["partner"]["id"], self.signer.id)
+        self.assertEqual(signer_info["partner"]["name"], "Signer")
 
     def test_request_field_edition(self):
         item = self.configure_request()


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/sign/pull/36

When a signer signs a request, we will want to fetch the info from his partner instead of fetching from the active user. This allows to load the correct data for signers that do not have a user in the system like customers.