### PR TITLE
[16.0][FIX] sign_oca: Filter correctly next_items

### DIFF
--- a/sign_oca/static/src/elements/check.esm.js
+++ b/sign_oca/static/src/elements/check.esm.js
@@ -42,7 +42,7 @@ const checkSignOca = {
             ev.preventDefault();
             var next_items = _.filter(
                 parent.info.items,
-                (i) => i.tabindex > item.tabindex && i.role_id === parent.role_id
+                (i) => i.tabindex > item.tabindex && i.role_id === parent.info.role_id
             ).sort((a, b) => a.tabindex - b.tabindex);
             if (next_items.length > 0) {
                 ev.currentTarget.blur();


### PR DESCRIPTION
When we click 'Horizontal Tab' character we would expect to move the focus to the next item. Correctly filtering the next_items we will be able to do so.

FWP from 14.0: https://github.com/OCA/sign/pull/37