### PR TITLE
[16.0][FIX]: Fix error on mig script when partner_type not exist

### DIFF
--- a/sign_oca/migrations/16.0.1.1.1/pre-migration.py
+++ b/sign_oca/migrations/16.0.1.1.1/pre-migration.py
@@ -9,7 +9,9 @@ def migrate(env, version):
     old_column_name = "partner_type"
     new_column_name = "partner_selection_policy"
 
-    if not openupgrade.column_exists(env.cr, "sign_oca_role", new_column_name):
+    if not openupgrade.column_exists(
+        env.cr, "sign_oca_role", new_column_name
+    ) and openupgrade.column_exists(env.cr, "sign_oca_role", old_column_name):
         openupgrade.rename_columns(
             env.cr,
             {


### PR DESCRIPTION
```
2024-06-28 17:36:58,697 58 INFO odoodb OpenUpgrade: table sign_oca_role, column partner_type: renaming to partner_selection_policy 
2024-06-28 17:36:58,700 58 ERROR odoodb odoo.sql_db: bad query: ALTER TABLE "sign_oca_role" RENAME "partner_type" TO "partner_selection_policy"
ERROR: column "partner_type" does not exist
 
2024-06-28 17:36:58,700 58 ERROR odoodb OpenUpgrade: sign_oca: error in migration script /odoo/external-src/sign/sign_oca/migrations/16.0.1.1.1/pre-migration.py: column "partner_type" does not exist
 
2024-06-28 17:36:58,700 58 ERROR odoodb OpenUpgrade: column "partner_type" does not exist
```
