### PR TITLE
[16.0][IMP] sign_oca: Use flex in order to show it properly

### DIFF
--- a/sign_oca/static/src/scss/portal.scss
+++ b/sign_oca/static/src/scss/portal.scss
@@ -1,5 +1,7 @@
 .o_sign_oca_content {
     height: 100%;
+    display: flex;
+    flex-direction: column;
 }
 .o_oca_sign_portal_info {
     display: flex;

--- a/sign_oca/static/src/scss/sign_oca.scss
+++ b/sign_oca/static/src/scss/sign_oca.scss
@@ -7,6 +7,8 @@
 html .o_web_client > .o_action_manager > .o_action > .o_content > .o_sign_oca_content {
     height: 100%;
     width: 100%;
+    display: flex;
+    flex-direction: column;
 }
 html
     .o_web_client


### PR DESCRIPTION
Fixes #43 
The same happened with the configuration