### PR TITLE
[16.0][FIX] sign_oca Fix sign button visibility

### DIFF
--- a/sign_oca/models/sign_oca_request.py
+++ b/sign_oca/models/sign_oca_request.py
@@ -362,14 +362,13 @@ class SignOcaRequestSigner(models.Model):
         for item in self.filtered(lambda x: x.request_id.record_ref):
             item.res_id = item.request_id.record_ref.id
 
-    @api.depends("signed_on", "partner_id", "partner_id.commercial_partner_id")
+    @api.depends("signed_on", "partner_id")
     @api.depends_context("uid")
     def _compute_is_allow_signature(self):
         user = self.env.user
         for item in self:
             item.is_allow_signature = bool(
-                not item.signed_on
-                and item.partner_id == user.partner_id.commercial_partner_id
+                not item.signed_on and item.partner_id == user.partner_id
             )
 
     def _compute_access_url(self):


### PR DESCRIPTION
Before this commit
------------------

Internal user cannot sign a document if this user's partner is a child of some other partner.

Example:
User "Pepe Frog" has a partner "Meme Inc, Pepe Frog" set as `user.partner_id`. This is because partner "Meme Inc" is set as a company for the partner "Pepe Frog". So when user Pepe Frog is assigned to a sign request he cannot see the "Sign" button.

After this commit
-----------------

User can see the "Sign" button and sign documents even if related partner has a parent partner set.

This highly likely should close #54 