### PR TITLE
[16.0][FIX] sign_oca: Avoid access error with ir.model

### DIFF
--- a/sign_oca/models/res_users.py
+++ b/sign_oca/models/res_users.py
@@ -31,7 +31,9 @@ class ResUsers(models.Model):
                     )
                     if total_records > 0:
                         record = self.env[model]
-                        model_id = self.env["ir.model"].search([("model", "=", model)])
+                        model_id = (
+                            self.env["ir.model"].sudo().search([("model", "=", model)])
+                        )
                         requests[model] = {
                             "id": model_id.id,
                             "name": record._description,

--- a/sign_oca/models/sign_oca_request.py
+++ b/sign_oca/models/sign_oca_request.py
@@ -41,9 +41,9 @@ class SignOcaRequest(models.Model):
     record_ref = fields.Reference(
         lambda self: [
             (m.model, m.name)
-            for m in self.env["ir.model"].search(
-                [("transient", "=", False), ("model", "not like", "sign.oca")]
-            )
+            for m in self.env["ir.model"]
+            .sudo()
+            .search([("transient", "=", False), ("model", "not like", "sign.oca")])
         ],
         string="Object",
         readonly=True,


### PR DESCRIPTION
Avoid access error with ir.model

Only "advanced" users have read access to `ir.model`, for this reason, we need to apply `.sudo()`

Please @pedrobaeza can you review it?

@Tecnativa 