### PR TITLE
[16.0][FIX] sign_oca: The id of the roles must be taken from role_id, not signer_id

### DIFF
--- a/sign_oca/models/sign_oca_request.py
+++ b/sign_oca/models/sign_oca_request.py
@@ -156,7 +156,7 @@ class SignOcaRequest(models.Model):
             "name": self.name,
             "items": self.signatory_data,
             "roles": [
-                {"id": signer.id, "name": signer.role_id.name}
+                {"id": signer.role_id.id, "name": signer.role_id.name}
                 for signer in self.signer_ids
             ],
             "fields": [


### PR DESCRIPTION
Otherwise, it does not work properly when signing documents created directly from a request (not coming from a template)