### PR TITLE
[16.0][IMP] sign_oca: Filter unsigned documents in user count

### DIFF
--- a/sign_oca/models/res_users.py
+++ b/sign_oca/models/res_users.py
@@ -17,6 +17,7 @@ class ResUsers(models.Model):
                 "child_of",
                 [self.env.user.partner_id.commercial_partner_id.id],
             ),
+            ("signed_on", "=", False),
         ]
         signer_model = self.env["sign.oca.request.signer"]
         signer_groups = signer_model.read_group(domain, ["model"], ["model"])


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/sign/pull/62

Filter unsigned documents in user count

Add ("signed_on", "=", False) to sign_oca_request_user_count domain
- Ensures only unsigned documents are counted
- Improves accuracy of pending signature notifications
- Prevents signed documents from appearing in user's to-sign list