### PR TITLE
[18.0][IMP] sign_oca: adding events for bus synchronization

### DIFF
--- a/sign_oca/__manifest__.py
+++ b/sign_oca/__manifest__.py
@@ -9,7 +9,7 @@
     "license": "AGPL-3",
     "author": "Dixmit,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/sign",
-    "depends": ["web_editor", "portal", "base_sparse_field"],
+    "depends": ["web_editor", "portal", "base_sparse_field", "bus"],
     "data": [
         "security/security.xml",
         "views/menu.xml",
@@ -48,6 +48,7 @@
             "sign_oca/static/src/elements/signature.esm.js",
             "sign_oca/static/src/elements/check.esm.js",
             "sign_oca/static/src/components/sign_oca_pdf/sign_oca_pdf.esm.js",
+            "sign_oca/static/src/js/sign_requests_service.esm.js",
             "sign_oca/static/src/js/sign_oca.esm.js",
             "sign_oca/static/src/js/systray_service.esm.js",
             "sign_oca/static/src/xml/*.xml",

--- a/sign_oca/__manifest__.py
+++ b/sign_oca/__manifest__.py
@@ -9,7 +9,7 @@
     "license": "AGPL-3",
     "author": "Dixmit,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/sign",
-    "depends": ["web_editor", "portal", "base_sparse_field", "bus"],
+    "depends": ["web_editor", "portal", "base_sparse_field"],
     "data": [
         "security/security.xml",
         "views/menu.xml",

--- a/sign_oca/models/sign_oca_request.py
+++ b/sign_oca/models/sign_oca_request.py
@@ -331,13 +331,10 @@ class SignOcaRequest(models.Model):
     @api.model
     def notify_changes(self, partner_recs):
         # send notification to the list of subscribers
-        partner_list_ids = partner_recs.mapped("id")
-        for partner_id in partner_list_ids:
-            self.env["bus.bus"]._sendone(
-                "broadcast",
-                f"sign_oca_request_updates_{partner_id}",
-                {"message": "Sign OCA Requests Model updated"},
-            )
+        channel = "sign_oca_request_updates"
+        message = {"message": "Sign OCA Requests Model updated"}
+        for partner_id in partner_recs:
+            partner_id._bus_send(channel, message)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/sign_oca/static/src/js/sign_requests_service.esm.js
+++ b/sign_oca/static/src/js/sign_requests_service.esm.js
@@ -1,0 +1,58 @@
+/** @odoo-module **/
+/* global */
+/* Copyright 2025 Kencove - Mohamed Alkobrosli
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+
+import {Reactive} from "@web/core/utils/reactive";
+import {reactive} from "@odoo/owl";
+import {registry} from "@web/core/registry";
+import {user} from "@web/core/user";
+
+export class WatchSignRequestsService extends Reactive {
+    static modelToLoad = [];
+    static serviceDependencies = ["bus_service", "orm", "notification"];
+
+    constructor() {
+        super();
+        this.ready = this.setup(...arguments).then(() => this);
+    }
+
+    async setup(env, {bus_service, orm, notification}) {
+        this.env = env;
+        this.bus_service = bus_service;
+        this.orm = orm;
+        this.notification = notification;
+        this.sign_requests = reactive({signerCounter: 0, signerGroups: []});
+
+        this.bus_service.subscribe(
+            `sign_oca_request_updates_${user.partnerId}`,
+            async ({message}) => {
+                if (message) {
+                    await this.fetchSystraySigner();
+                }
+            }
+        );
+    }
+    async fetchSystraySigner() {
+        const groups = await this.orm.call("res.users", "sign_oca_request_user_count");
+        let total = 0;
+        for (const group of groups) {
+            total += group.total_records || 0;
+        }
+        this.sign_requests.signerGroups = groups;
+        this.sign_requests.signerCounter = total;
+        return {groups, total};
+    }
+    getTotalSignRequests() {
+        return this.sign_requests.signerCounter;
+    }
+}
+
+export const watchSignRequestsService = {
+    dependencies: WatchSignRequestsService.serviceDependencies,
+    async start(env, services) {
+        return new WatchSignRequestsService(env, services).ready;
+    },
+};
+
+registry.category("services").add("watchSignRequests", watchSignRequestsService);

--- a/sign_oca/static/src/js/sign_requests_service.esm.js
+++ b/sign_oca/static/src/js/sign_requests_service.esm.js
@@ -6,7 +6,6 @@
 import {Reactive} from "@web/core/utils/reactive";
 import {reactive} from "@odoo/owl";
 import {registry} from "@web/core/registry";
-import {user} from "@web/core/user";
 
 export class WatchSignRequestsService extends Reactive {
     static modelToLoad = [];
@@ -24,14 +23,11 @@ export class WatchSignRequestsService extends Reactive {
         this.notification = notification;
         this.sign_requests = reactive({signerCounter: 0, signerGroups: []});
 
-        this.bus_service.subscribe(
-            `sign_oca_request_updates_${user.partnerId}`,
-            async ({message}) => {
-                if (message) {
-                    await this.fetchSystraySigner();
-                }
+        this.bus_service.subscribe("sign_oca_request_updates", async ({message}) => {
+            if (message) {
+                await this.fetchSystraySigner();
             }
-        );
+        });
     }
     async fetchSystraySigner() {
         const groups = await this.orm.call("res.users", "sign_oca_request_user_count");

--- a/sign_oca/static/src/js/systray_service.esm.js
+++ b/sign_oca/static/src/js/systray_service.esm.js
@@ -15,25 +15,13 @@ export class SignerMenuView extends Component {
         this.discussSystray = useDiscussSystray();
         this.orm = useService("orm");
         this.action = useService("action");
+        this.watchSignRequests = useService("watchSignRequests");
         this.state = useState({
-            signerGroups: [],
-            signerCounter: 0,
+            sign_requests: this.watchSignRequests.sign_requests,
         });
         onMounted(async () => {
-            await this.fetchSystraySigner();
+            await this.watchSignRequests.fetchSystraySigner();
         });
-    }
-    async fetchSystraySigner() {
-        const groups = await this.orm.call("res.users", "sign_oca_request_user_count");
-        let total = 0;
-        for (const group of groups) {
-            total += group.total_records || 0;
-        }
-        this.state.signerCounter = total;
-        this.state.signerGroups = groups;
-    }
-    async onBeforeOpen() {
-        await this.fetchSystraySigner();
     }
     availableViews() {
         return [

--- a/sign_oca/static/src/xml/systray.xml
+++ b/sign_oca/static/src/xml/systray.xml
@@ -3,7 +3,6 @@
     <t t-name="sign_oca.SignerMenu">
         <Dropdown
             position="'bottom-end'"
-            beforeOpen.bind="onBeforeOpen"
             manual="false"
             menuClass="discussSystray.menuClass"
         >
@@ -11,16 +10,16 @@
                 <div class="o-mail-DiscussSystray-class cursor-pointer">
                     <i class="fa fa-pencil" role="img" aria-label="Sign Requests" />
                     <span
-                        t-if="state.signerCounter > 0"
+                        t-if="state.sign_requests.signerCounter > 0"
                         class="o-mail-ActivityMenu-counter badge rounded-pill"
-                        t-out="state.signerCounter"
+                        t-out="state.sign_requests.signerCounter"
                     />
                 </div>
             </t>
             <t t-set-slot="content">
                 <div t-att-class="`${discussSystray.contentClass} o-mail-ActivityMenu`">
                     <div
-                        t-if="state.signerCounter === 0"
+                        t-if="state.sign_requests.signerCounter === 0"
                         class="o-mail-ActivityMenu-empty align-items-center text-muted p-2 opacity-50 d-flex justify-content-center"
                     >
                         <span>No requests to sign.</span>
@@ -30,7 +29,7 @@
                         name="activityGroups"
                     >
                         <t
-                            t-foreach="state.signerGroups"
+                            t-foreach="state.sign_requests.signerGroups"
                             t-as="group"
                             t-key="group_index"
                             name="activityGroupLoop"


### PR DESCRIPTION
In this new feature, web client user can observe each sign request update in the status bar without needing to reload the page or even clicking on the pen icon.

Observe that event is sent only to scoped users who should sign on the new created sign request. and not for everybody.