### PR TITLE
[16.0][FIX] sign_oca: Fixed two issues in signature module

### DIFF
--- a/sign_oca/static/src/components/sign_oca_pdf_portal/sign_oca_pdf_portal.esm.js
+++ b/sign_oca/static/src/components/sign_oca_pdf_portal/sign_oca_pdf_portal.esm.js
@@ -8,6 +8,7 @@ import env from "web.public_env";
 import {renderToString} from "@web/core/utils/render";
 import session from "web.session";
 import {templates} from "@web/core/assets";
+
 export class SignOcaPdfPortal extends SignOcaPdf {
     setup() {
         super.setup(...arguments);
@@ -79,11 +80,20 @@ export function initDocumentToSign(properties) {
         ]).then(async function () {
             var app = new App(null, {templates, test: true});
             renderToString.app = app;
-            mount(SignOcaPdfPortal, document.body, {
-                env,
-                props: properties,
-                templates: templates,
-            });
+
+            let dialogService = env.services.dialog;
+            const dialogServiceInterval = setInterval(() => {
+                if (dialogService) {
+                    clearInterval(dialogServiceInterval);
+                    mount(SignOcaPdfPortal, document.body, {
+                        env,
+                        props: properties,
+                        templates: templates,
+                    });
+                } else {
+                    dialogService = env.services.dialog;
+                }
+            }, 100);
         });
     });
 }

--- a/sign_oca/static/src/scss/sign.scss
+++ b/sign_oca/static/src/scss/sign.scss
@@ -16,6 +16,8 @@
         border: transparent;
         background-color: transparent;
     }
+
+    z-index: 2147483647; // highest possible css zindex to ensure that the field is never overlapped
 }
 .o_sign_oca_field_config {
     position: absolute;


### PR DESCRIPTION
This pull request fixes two issues: 

1) Signature-wizard sometimes does not open

When loading a document to sign using the sign_oca module in Odoo 16, the dialog service is sometimes unavailable during the first page load. This causes an error when attempting to access env.services.dialog. However, after a manual page reload, the issue disappears, indicating a race condition in service initialization.

Root cause:

- The dialog service is initialized asynchronously and may not be available when the SignOcaPdfPortal component is mounted.
- This results in an undefined error when trying to use env.services.dialog.
- The issue is caused by the load order of frontend assets and the delayed initialization of services in Odoo 16.

Solution:

- Implement a polling mechanism using setInterval() to check for the availability of env.services.dialog before mounting SignOcaPdfPortal.
- Once the dialog service is available, stop the polling (clearInterval()) and proceed with the component initialization.

2) Signature-field is sometimes overlapped by other elements

In some cases (based on the pdf content) the signature field is overlapped by the pdf content. This can be fixed by giving the signature field the highest possible z-level.