### PR TITLE
[16.0][FIX] sign_oca: Prevent duplicate dialogs per item

### DIFF
--- a/sign_oca/static/src/elements/signature.esm.js
+++ b/sign_oca/static/src/elements/signature.esm.js
@@ -22,29 +22,36 @@ const signatureSignOca = {
             core.qweb.render("sign_oca.sign_iframe_field_signature", {item: item})
         )[0];
         if (item.role_id === parent.info.role_id) {
+            const requestOpenDialog = () => {
+                if (!item.dialogOpened) {
+                    item.dialogOpened = true;
+                    var signatureOptions = {
+                        fontColor: "DarkBlue",
+                        defaultName: parent.info.partner.name,
+                    };
+                    parent.env.services.dialog.add(
+                        SignatureDialog,
+                        {
+                            ...signatureOptions,
+                            uploadSignature: (data) =>
+                                this.uploadSignature(parent, item, signatureItem, data),
+                        },
+                        {
+                            onClose: () => {
+                                item.dialogOpened = false;
+                            },
+                        }
+                    );
+                }
+            };
+
             signatureItem[0].addEventListener("focus_signature", () => {
-                var signatureOptions = {
-                    fontColor: "DarkBlue",
-                    defaultName: parent.info.partner.name,
-                };
-                parent.env.services.dialog.add(SignatureDialog, {
-                    ...signatureOptions,
-                    uploadSignature: (data) =>
-                        this.uploadSignature(parent, item, signatureItem, data),
-                });
+                requestOpenDialog();
             });
             input.addEventListener("click", (ev) => {
                 ev.preventDefault();
                 ev.stopPropagation();
-                var signatureOptions = {
-                    fontColor: "DarkBlue",
-                    defaultName: parent.info.partner.name,
-                };
-                parent.env.services.dialog.add(SignatureDialog, {
-                    ...signatureOptions,
-                    uploadSignature: (data) =>
-                        this.uploadSignature(parent, item, signatureItem, data),
-                });
+                requestOpenDialog();
             });
             input.addEventListener("keydown", (ev) => {
                 if ((ev.keyCode || ev.which) !== 9) {


### PR DESCRIPTION
Prevent Multiple Dialog Openings for the Same Item

Description

This PR addresses an issue in the sign_oca module where multiple dialogs could be opened for the same item, leading to redundant UI elements and potential user confusion. The issue was further exacerbated by a request delay on:

🔗 http://.../web/sign/get_fonts/

To resolve this, an item-specific guard (item.dialogOpened) has been implemented to prevent duplicate dialog openings for the same item while still allowing different items to open their respective dialogs concurrently.

Changes Made

✅ Added an item-level flag (item.dialogOpened) to prevent duplicate dialogs.
✅ Ensured dialogs reset properly when closed.
✅ Prevented multiple openings due to the request delay on /web/sign/get_fonts/.
✅ Ensured no impact on concurrent dialogs for different items.

Steps to Reproduce the Issue (Before Fix)

Open a signature field in the sign_oca module.
Rapidly trigger the dialog opening action (e.g., clicking multiple times).
Observe that multiple dialogs are opened for the same item.

Expected Behavior (After Fix)

✔️ Only one dialog can be opened per item at a time.
✔️ Different items can still open their own dialogs.
✔️ The fix handles request delays gracefully and prevents unintended duplicate openings.