### PR TITLE
[16.0][FIX] sign_oca: list requests from recent sent to oldest signed

### DIFF
--- a/sign_oca/README.rst
+++ b/sign_oca/README.rst
@@ -147,6 +147,10 @@ Contributors
 
   - Víctor Martínez
 
+- `Kencove <https://www.kencove.com>`__:
+
+  - Mohamed Alkobrosli
+
 Maintainers
 -----------
 

--- a/sign_oca/models/sign_oca_request.py
+++ b/sign_oca/models/sign_oca_request.py
@@ -25,6 +25,7 @@ class SignOcaRequest(models.Model):
     _name = "sign.oca.request"
     _inherit = ["mail.thread", "mail.activity.mixin"]
     _description = "Sign Request"
+    _order = "sequence, create_date desc, id desc"
 
     name = fields.Char(required=True)
     active = fields.Boolean(default=True)
@@ -81,6 +82,7 @@ class SignOcaRequest(models.Model):
         copy=False,
         tracking=True,
     )
+    sequence = fields.Integer(compute="_compute_sequence", store=True)
     signed_count = fields.Integer(compute="_compute_signed_count")
     signer_count = fields.Integer(compute="_compute_signer_count")
     to_sign = fields.Boolean(compute="_compute_to_sign")
@@ -239,6 +241,18 @@ class SignOcaRequest(models.Model):
         for record in self:
             record.signer_count = len(record.signer_ids)
 
+    @api.depends("state")
+    def _compute_sequence(self):
+        for rec in self:
+            if rec.state == "sent":
+                rec.sequence = 0
+            elif rec.state == "draft":
+                rec.sequence = 1
+            elif rec.state == "signed":
+                rec.sequence = 2
+            else:
+                rec.sequence = 3
+
     @api.depends("signer_ids", "signer_ids.signed_on")
     def _compute_signed_count(self):
         for record in self:
@@ -347,6 +361,7 @@ class SignOcaRequestSigner(models.Model):
     _name = "sign.oca.request.signer"
     _inherit = "portal.mixin"
     _description = "Sign Request Value"
+    _order = "signed_on desc, create_date desc, id desc"
 
     data = fields.Binary(related="request_id.data")
     request_id = fields.Many2one("sign.oca.request", required=True, ondelete="cascade")

--- a/sign_oca/readme/CONTRIBUTORS.md
+++ b/sign_oca/readme/CONTRIBUTORS.md
@@ -1,3 +1,5 @@
 - Enric Tobella (www.dixmit.com)
 - [Tecnativa](https://www.tecnativa.com):
   - Víctor Martínez
+- [Kencove](https://www.kencove.com):
+  - Mohamed Alkobrosli

--- a/sign_oca/static/description/index.html
+++ b/sign_oca/static/description/index.html
@@ -511,6 +511,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Víctor Martínez</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.kencove.com">Kencove</a>:<ul>
+<li>Mohamed Alkobrosli</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
If we have a thousand of requests, it is quite hard to check them as they are listed in ascending way.

In real world we need to inspect not signed and top recent requests.
In the same way no need to see signed requests or canceled requests at the top of the list, but at the end instead.

![Screenshot from 2025-03-04 01-40-43](https://github.com/user-attachments/assets/468edb32-41e5-45d9-9cad-c18fca5e11fb)
![Screenshot from 2025-03-04 01-21-52](https://github.com/user-attachments/assets/929bf14e-b54b-4400-8dc3-da612c086139)
