### PR TITLE
[16.0][IMP] sign_oca: add resend feature to partners who did not sign

### DIFF
--- a/sign_oca/models/sign_oca_request.py
+++ b/sign_oca/models/sign_oca_request.py
@@ -255,23 +255,9 @@ class SignOcaRequest(models.Model):
         self._set_action_log("validate")
         self.state = "0_sent"
         for signer in self.signer_ids:
-            signer._portal_ensure_token()
             if sign_now and signer.partner_id == self.env.user.partner_id:
                 continue
-            render_result = self.env["ir.qweb"]._render(
-                "sign_oca.sign_oca_template_mail",
-                {"record": signer, "body": message, "link": signer.access_url},
-                engine="ir.qweb",
-                minimal_qcontext=True,
-            )
-            self.env["mail.thread"].message_notify(
-                body=render_result,
-                partner_ids=signer.partner_id.ids,
-                subject=_("New document to sign"),
-                subtype_id=self.env.ref("mail.mt_comment").id,
-                mail_auto_delete=False,
-                email_layout_xmlid="mail.mail_notification_light",
-            )
+            signer.action_send(sign_now, message)
 
     def action_send_signed_request(self):
         self.ensure_one()
@@ -445,6 +431,27 @@ class SignOcaRequestSigner(models.Model):
             "type": "ir.actions.act_url",
             "url": self.access_url,
         }
+
+    def action_send(self, sign_now=False, message=""):
+        self.ensure_one()
+        if self.signed_on or (sign_now and self.partner_id == self.env.user.partner_id):
+            return
+        self._portal_ensure_token()
+        render_result = self.env["ir.qweb"]._render(
+            "sign_oca.sign_oca_template_mail",
+            {"record": self, "body": message, "link": self.access_url},
+            engine="ir.qweb",
+            minimal_qcontext=True,
+        )
+        # send the message to partners who didn't sign only
+        self.env["mail.thread"].message_notify(
+            body=render_result,
+            partner_ids=self.partner_id.ids,
+            subject=_("New document to sign"),
+            subtype_id=self.env.ref("mail.mt_comment").id,
+            mail_auto_delete=False,
+            email_layout_xmlid="mail.mail_notification_light",
+        )
 
     def action_sign(self, items, access_token=False, latitude=False, longitude=False):
         self.ensure_one()

--- a/sign_oca/views/sign_oca_request.xml
+++ b/sign_oca/views/sign_oca_request.xml
@@ -111,6 +111,14 @@
                         <tree editable="bottom">
                             <field name="role_id" />
                             <field name="partner_id" />
+                            <button
+                                string="Send"
+                                type="object"
+                                attrs="{'invisible': [('signed_on', '!=', False)]}"
+                                name="action_send"
+                                icon="fa-paper-plane"
+                                confirm="Are you sure ?"
+                            />
                             <field name="signed_on" />
                         </tree>
                     </field>
@@ -306,6 +314,15 @@
                                             widget="kanban_activity"
                                         />
                                     </div>
+                                    <button
+                                        string="Send"
+                                        type="object"
+                                        states="1_draft,0_sent"
+                                        name="action_send"
+                                        icon="fa-paper-plane"
+                                        confirm="Are you sure ?"
+                                        class="btn btn-primary btn-sm"
+                                    />
                                 </div>
                                 <div class="oe_kanban_bottom_right">
                                     <field
@@ -331,6 +348,14 @@
                 <field name="request_id" />
                 <field name="signed_on" />
                 <field name="altered_hash" invisible="1" />
+                <button
+                    string="Send"
+                    type="object"
+                    attrs="{'invisible': [('signed_on', '!=', False)]}"
+                    name="action_send"
+                    icon="fa-paper-plane"
+                    confirm="Are you sure ?"
+                />
             </tree>
         </field>
     </record>
@@ -345,6 +370,14 @@
                         type="object"
                         name="sign"
                         attrs="{'invisible': [('is_allow_signature', '=', False)]}"
+                    />
+                    <button
+                        string="Send"
+                        type="object"
+                        attrs="{'invisible': [('signed_on', '!=', False)]}"
+                        name="action_send"
+                        icon="fa-paper-plane"
+                        confirm="Are you sure ?"
                     />
                 </header>
                 <sheet>


### PR DESCRIPTION
Sometimes we can resend the sign request for some partners and find that a new one is created although some people have already signed the previous one.

In that case we will have to resign agin which is extra needed

This PR is allow to resend the email or sms of the same sign request to be signed, also there is an option to allow creating request for once.

#87 

unsubscribe feature is added to avoid sending emails to partners who are not interested.

Only partners who didn't sign and still followers to the specific sign request are receiving the email notifications.