### PR TITLE
[16.0][IMP] sign_oca enable the user to select all the value of type char, text or m2o from the res.partner object

### DIFF
--- a/sign_oca/models/sign_oca_field.py
+++ b/sign_oca/models/sign_oca_field.py
@@ -14,4 +14,8 @@ class SignOcaField(models.Model):
         required=True,
         default="text",
     )
-    default_value = fields.Char()
+    default_value = fields.Char(
+        help="If filled with the technical name of a field of type char or text "
+        "linked to the template model when it is res.partner, the value will be "
+        "precompiled."
+    )

--- a/sign_oca/models/sign_oca_request.py
+++ b/sign_oca/models/sign_oca_request.py
@@ -18,6 +18,7 @@ from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.http import request
 from odoo.tools import float_repr
+from odoo.tools.misc import get_lang
 
 
 class SignOcaRequest(models.Model):
@@ -413,18 +414,35 @@ class SignOcaRequestSigner(models.Model):
     def get_info(self, access_token=False):
         self.ensure_one()
         self._set_action_log("view", access_token=access_token)
+        partner_fields_dict = {"id": self.partner_id.id}
+        for field_name, field_info in (
+            self.env["res.partner"]
+            .with_user(self.partner_id.user_id)
+            .fields_get()
+            .items()
+        ):
+            if field_info["type"] in ["char", "text"]:
+                partner_fields_dict.update({field_name: self.partner_id[field_name]})
+            if field_info["type"] == "many2one":
+                partner_fields_dict.update(
+                    {field_name: self.partner_id[field_name].name}
+                )
+        # add current_date formatted string too
+        lang_id = get_lang(self.env, self.env.user.lang)
+        partner_fields_dict.update(
+            {
+                "current_date": fields.Date.context_today(self).strftime(
+                    lang_id.date_format
+                )
+            }
+        )
         return {
             "role_id": self.role_id.id if not self.signed_on else False,
             "name": self.request_id.template_id.name,
             "items": self.request_id.signatory_data,
             "to_sign": self.request_id.to_sign,
             "ask_location": self.request_id.ask_location,
-            "partner": {
-                "id": self.partner_id.id,
-                "name": self.partner_id.name,
-                "email": self.partner_id.email,
-                "phone": self.partner_id.phone,
-            },
+            "partner": partner_fields_dict,
         }
 
     def sign(self):

--- a/sign_oca/views/sign_oca_field.xml
+++ b/sign_oca/views/sign_oca_field.xml
@@ -16,6 +16,7 @@
                     <group>
                         <field name="name" />
                         <field name="field_type" />
+                        <field name="default_value" />
                     </group>
                 </sheet>
             </form>


### PR DESCRIPTION
With this PR all fields of type char, text and m2o are pre-filled during sign request, if model used is `res.partner`.