### PR TITLE
[FIX] sign_oca: raise_if_not_found in default _get_sequence

### DIFF
--- a/sign_oca/models/sign_oca_request.py
+++ b/sign_oca/models/sign_oca_request.py
@@ -592,7 +592,9 @@ class SignOcaRequestSigner(models.Model):
         return result
 
     def _get_sequence(self):
-        return self.env.ref("sign_oca.sign_inalterability_sequence")
+        return self.env.ref(
+            "sign_oca.sign_inalterability_sequence", raise_if_not_found=False
+        )
 
     @api.depends(
         lambda r: ["request_id.data", "inalterable_hash", "secure_sequence_number"]


### PR DESCRIPTION
If updating module from previous version from commit https://github.com/OCA/sign/commit/fe566965097e49b9d1082430c359da4e57f1e457 , we encountered issues not finding external id sign_oca.sign_inalterability_sequence.
The reason is that when updating an odoo module, first models are loaded what will trigger default method from field sequence_id https://github.com/OCA/sign/blob/16.0/sign_oca/models/sign_oca_request.py#L595 . At this point file https://github.com/OCA/sign/blob/16.0/sign_oca/data/ir_sequence_data.xml still not loaded, that is the reason of error.

Including raise_if_not_found we avoid that issue.