### PR TITLE
[16.0][FIX] project_task_sign_oca: Proper comparison to avoid warning log

### DIFF
--- a/project_task_sign_oca/models/project_task.py
+++ b/project_task_sign_oca/models/project_task.py
@@ -55,6 +55,6 @@ class ProjectTask(models.Model):
         old_partner_id = self.partner_id
         new_partner_id = vals.get("partner_id")
         res = super().write(vals)
-        if new_partner_id and new_partner_id != old_partner_id:
+        if new_partner_id and new_partner_id != old_partner_id.id:
             self._generate_sign_oca_request()
         return res


### PR DESCRIPTION
Proper comparison to avoid warning log

`WARNING devel py.warnings: /opt/odoo/auto/addons/project_task_sign_oca/models/project_task.py:58: UserWarning: unsupported operand type(s) for "==": 'res.partner()' == '42'`

@Tecnativa