### PR TITLE
[FIX] sign_oca: correct syntax and handle js logic

### DIFF
--- a/sign_oca/static/src/elements/check.esm.js
+++ b/sign_oca/static/src/elements/check.esm.js
@@ -46,9 +46,12 @@ const checkSignOca = {
             ).sort((a, b) => a.tabindex - b.tabindex);
             if (next_items.length > 0) {
                 ev.currentTarget.blur();
-                parent.items[next_items[0].id].dispatchEvent(
-                    new Event("focus_signature")
-                );
+                const nextItem = next_items[0];
+                if (nextItem && parent.items && parent.items[nextItem.id]) {
+                    parent.items[nextItem.id].dispatchEvent(
+                        new Event("focus_signature")
+                    );
+                }
             }
         });
         return input;

--- a/sign_oca/static/src/elements/signature.esm.js
+++ b/sign_oca/static/src/elements/signature.esm.js
@@ -14,7 +14,10 @@ const signatureSignOca = {
             (i) => i.tabindex > item.tabindex
         ).sort((a, b) => a.tabindex - b.tabindex);
         if (next_items.length > 0) {
-            parent.items[next_items[0].id].dispatchEvent(new Event("focus_signature"));
+            const nextItem = next_items[0];
+            if (nextItem && parent.items && parent.items[nextItem.id]) {
+                parent.items[nextItem.id].dispatchEvent(new Event("focus_signature"));
+            }
         }
     },
     generate: function (parent, item, signatureItem) {
@@ -58,9 +61,12 @@ const signatureSignOca = {
                 );
                 if (next_items.length > 0) {
                     ev.currentTarget.blur();
-                    parent.items[next_items[0].id].dispatchEvent(
-                        new Event("focus_signature")
-                    );
+                    const nextItem = next_items[0];
+                    if (nextItem && parent.items && parent.items[nextItem.id]) {
+                        parent.items[nextItem.id].dispatchEvent(
+                            new Event("focus_signature")
+                        );
+                    }
                 }
             });
         }

--- a/sign_oca/static/src/elements/text.esm.js
+++ b/sign_oca/static/src/elements/text.esm.js
@@ -46,9 +46,12 @@ const textSignOca = {
             ).sort((a, b) => a.tabindex - b.tabindex);
             if (next_items.length > 0) {
                 ev.currentTarget.blur();
-                parent.items[next_items[0].id].dispatchEvent(
-                    new Event("focus_signature")
-                );
+                const nextItem = next_items[0];
+                if (nextItem && parent.items && parent.items[nextItem.id]) {
+                    parent.items[nextItem.id].dispatchEvent(
+                        new Event("focus_signature")
+                    );
+                }
             }
         });
         return input;


### PR DESCRIPTION
Role correct syntax is between {{ }} not ${}, this will cause error. parent.items[nextItem.id] if is not defined the function dispatchEvent will throw error in the UI, so it is better to handle that error.