### PR TITLE
[16.0][IMP] sign_oca: add back to draft action button

### DIFF
--- a/sign_oca/models/sign_oca_request.py
+++ b/sign_oca/models/sign_oca_request.py
@@ -254,7 +254,7 @@ class SignOcaRequest(models.Model):
 
     def action_send(self, sign_now=False, message=""):
         self.ensure_one()
-        if self.state != "1_draft":
+        if self.state not in ["1_draft", "0_sent"]:
             return
         self._set_action_log("validate")
         self.state = "0_sent"
@@ -268,14 +268,16 @@ class SignOcaRequest(models.Model):
                 engine="ir.qweb",
                 minimal_qcontext=True,
             )
-            self.env["mail.thread"].message_notify(
-                body=render_result,
-                partner_ids=signer.partner_id.ids,
-                subject=_("New document to sign"),
-                subtype_id=self.env.ref("mail.mt_comment").id,
-                mail_auto_delete=False,
-                email_layout_xmlid="mail.mail_notification_light",
-            )
+            # send the message to partners who didn't sign only
+            if not signer.signed_on:
+                self.env["mail.thread"].message_notify(
+                    body=render_result,
+                    partner_ids=signer.partner_id.ids,
+                    subject=_("New document to sign"),
+                    subtype_id=self.env.ref("mail.mt_comment").id,
+                    mail_auto_delete=False,
+                    email_layout_xmlid="mail.mail_notification_light",
+                )
 
     def action_send_signed_request(self):
         self.ensure_one()

--- a/sign_oca/models/sign_oca_request.py
+++ b/sign_oca/models/sign_oca_request.py
@@ -235,6 +235,10 @@ class SignOcaRequest(models.Model):
         self.write({"state": "3_cancel"})
         self._set_action_log("cancel")
 
+    def action_reset_to_draft(self):
+        self.write({"state": "1_draft"})
+        self._set_action_log("to_draft")
+
     @api.depends("signer_ids")
     def _compute_signer_count(self):
         for record in self:
@@ -700,6 +704,7 @@ class SignRequestLog(models.Model):
             ("delete_field", "Delete field"),
             ("cancel", "Cancel"),
             ("configure", "Configure"),
+            ("to_draft", "Reset to Draft"),
         ],
         required=True,
         readonly=True,

--- a/sign_oca/views/sign_oca_request.xml
+++ b/sign_oca/views/sign_oca_request.xml
@@ -32,6 +32,14 @@
                         confirm="You will cancel the request and all the accesses. Are you sure about it?"
                         groups="sign_oca.sign_oca_group_user"
                     />
+                    <button
+                        string="Back to Draft"
+                        type="object"
+                        states="3_cancel"
+                        name="action_reset_to_draft"
+                        confirm="You will reset the request to draft. Are you sure about it?"
+                        groups="sign_oca.sign_oca_group_user"
+                    />
                     <field
                         name="state"
                         widget="statusbar"


### PR DESCRIPTION
In a competition with: https://github.com/OCA/sign/pull/89

Only one is planned to be merged or we can take the best of both in one single thing.