### PR TITLE
[16.0][FIX] sign_oca: Fix warnings in sign_oca

### DIFF
--- a/sign_oca/models/sign_oca_template.py
+++ b/sign_oca/models/sign_oca_template.py
@@ -21,7 +21,9 @@ class SignOcaTemplate(models.Model):
         string="Model",
         domain=[("transient", "=", False), ("model", "not like", "sign.oca")],
     )
-    model = fields.Char(compute="_compute_model", compute_sudo=True, store=True)
+    model = fields.Char(
+        compute="_compute_model", compute_sudo=True, store=True, string="Model name"
+    )
     active = fields.Boolean(default=True)
     request_ids = fields.One2many("sign.oca.request", inverse_name="template_id")
 


### PR DESCRIPTION
  Warnings from "sign_oca_template" model related to using same label is addressed.
  
  Below is the warning displayed:
  2025-11-07 10:07:06,387 21 WARNING devel odoo.addons.base.models.ir_model: Two fields (model, model_id) of sign.oca.template() have the same label: Model. [Modules: sign_oca and sign_oca]