### PR TITLE
[IMP] sign_oca: Add error handling for corrupted PDFs

### DIFF
--- a/sign_oca/models/sign_oca_request.py
+++ b/sign_oca/models/sign_oca_request.py
@@ -445,7 +445,16 @@ class SignOcaRequestSigner(models.Model):
         signatory_data = self.request_id.signatory_data
 
         input_data = BytesIO(b64decode(self.request_id.data))
-        reader = PdfFileReader(input_data)
+        try:
+            reader = PdfFileReader(input_data, strict=False)
+        except Exception as e:  # pragma: no cover
+            _logger.error("Error reading PDF: %s", str(e))
+            raise ValidationError(
+                self.env._(
+                    "The PDF file appears to be corrupted or contains "
+                    "invalid characters. Please upload a valid PDF file."
+                )
+            ) from e
         output = PdfFileWriter()
         pages = {}
         for page_number in range(1, reader.numPages + 1):
@@ -464,7 +473,17 @@ class SignOcaRequestSigner(models.Model):
         for page_number in pages:
             output.addPage(pages[page_number])
         output_stream = BytesIO()
-        output.write(output_stream)
+        try:
+            output.write(output_stream)
+        except Exception as e:  # pragma: no cover
+            _logger.error("Error writing PDF: %s", str(e))
+            raise ValidationError(
+                self.env._(
+                    "The PDF file appears to be corrupted or contains invalid "
+                    "characters that prevent signing. Please try re-generating "
+                    "the PDF or use a different PDF tool to create a valid file."
+                )
+            ) from e
         output_stream.seek(0)
         signed_pdf = output_stream.read()
         final_hash = hashlib.sha1(signed_pdf).hexdigest()


### PR DESCRIPTION
- Use strict=False to handle PDFs with minor format issues
- Add try-catch for PDF read operations with clear error messages
- Add try-catch for PDF write operations with helpful user feedback
- Prevent crashes when processing PDFs with encoding issues

This improvement handles PDFs that contain encoding problems or illegal characters that would normally cause PyPDF2 to fail with PdfReadError, providing a more robust document signing experience.