### PR TITLE
[17.0][FIX] sign_oca: Use odoo pdf libraries

### DIFF
--- a/sign_oca/models/sign_oca_request.py
+++ b/sign_oca/models/sign_oca_request.py
@@ -7,7 +7,6 @@ from base64 import b64decode, b64encode
 from hashlib import sha256
 from io import BytesIO
 
-from PyPDF2 import PdfFileReader, PdfFileWriter
 from reportlab.graphics.shapes import Drawing, Line, Rect
 from reportlab.lib.colors import black, transparent
 from reportlab.lib.styles import ParagraphStyle
@@ -18,6 +17,7 @@ from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.http import request
 from odoo.tools import float_repr
+from odoo.tools.pdf import PdfFileReader, PdfFileWriter
 
 
 class SignOcaRequest(models.Model):


### PR DESCRIPTION
## Description

Backport of #160 to **17.0** via **cherry-pick**.

Cherry-picked commit:
- `6a78bfb` — `[FIX] sign_oca: Use odoo pdf libraries` (author: @etobella)

Applied cleanly on `17.0` with no extra commits needed.

`project_task_sign_oca` follow-up commit from #160 (`757b336`) was **not** cherry-picked: it adjusts `Form` imports for 18.0 and is not applicable on 17.0.

## Related

- Backport of #160
- Related to #152

## Checklist

- [x] Cherry-picked from the merged 18.0 fix
- [x] Followed OCA contribution guidelines